### PR TITLE
Add version 0.0.0 to fpm.toml

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -1,4 +1,5 @@
 name="stdlib"
+version = "0.0.0"
 license = "MIT"
 author = "stdlib contributors"
 copyright = "2020 stdlib contributors"


### PR DESCRIPTION
Fixes #10.
I think I am right in saying that stdlib has [not yet adopted a version](https://github.com/fortran-lang/stdlib/issues/292) number, so I have set it to 0.0.0 in the manifest for now.